### PR TITLE
Add a Swiss editorial landing page for Tracklet

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -209,6 +209,19 @@ The aesthetic draws from modern fintech apps (Revolut, Chime) adapted to the loc
 
 **Guiding principle**: every screen must answer a question in under 2 seconds without the user having to search. Key financial information (balance, margin, debts) is always front and center.
 
+## Public landing direction
+
+The public landing page uses a Swiss editorial system distinct from the operational app shell. Its purpose is explanation and orientation, not financial data entry.
+
+- **Surface:** pure white (`#FFFFFF`) and neutral (`#F7F7F8`).
+- **Accent:** Yves Klein blue (`#002FA7`) only.
+- **Typography:** Helvetica Neue or a system Helvetica/Arial fallback, left aligned with tightly tracked display headings.
+- **Structure:** asymmetric sections, visible 1px grid lines, square controls, and large numerals as composition elements.
+- **Restrictions:** no gradients, grain, decorative shadows, fabricated balances, customer counts, or testimonials.
+- **Signature motif:** personal and business pockets remain visibly separated before converging into one cash-position explanation.
+
+The product mockup on the landing names real Tracklet concepts but never pretends that sample balances are user data. Once the user opens `/#/dashboard`, the operational interface returns to the mobile-first tokens documented below.
+
 ## Colors
 
 The palette is built around a single strong royal blue (`#185FA5`) as the primary color — a universal fintech trust color, readable on white backgrounds, strong in mobile contexts.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Tracklet is a local-first financial copilot for young micro-entrepreneurs in Bur
 
 ## Alpha features
 
+- Public French landing page with a direct entry into the local application
 - Pockets and balances
 - Income, expenses, and atomic transfers between pockets
 - Debts and receivables
@@ -57,4 +58,4 @@ Browser storage is the source of truth. Clearing site data or uninstalling the P
 - Goal contributions track progress but do not move pocket balances
 - Contextual tips are local rules, not an LLM
 
-The legacy Next.js/Supabase application remains in Git history and on the `legacy/tracklet-finance-app` branch. The current product direction lives on `feat/repurpose-tracklet`.
+The legacy Next.js/Supabase application remains in Git history and on the `legacy/tracklet-finance-app` branch. The local-first product is the current direction on `main`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,12 +24,18 @@ React UI + HashRouter
 
 - React 19 and React Router
 - Vite 8 with the PWA plugin
-- TypeScript 6
+- TypeScript 7
 - Tailwind CSS 4
 - IndexedDB through `idb`
 - Vitest and `fake-indexeddb` for automated verification
 
 `index.html`, `vite.config.ts`, TypeScript configuration, and PWA assets are source-controlled. `dist/` is generated and ignored.
+
+## Presentation and routes
+
+The hash route `/#/` renders the public French landing page without the application shell. It presents only implemented product capabilities and links to `/#/dashboard`. Financial routes render inside the authenticated-free application layout; they remain directly addressable for existing bookmarks.
+
+The installed PWA starts at `/#/dashboard`, so returning users enter their financial workspace directly instead of passing through the marketing page on every launch.
 
 ## Data model
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -45,3 +45,4 @@ A young Burkinabe micro-entrepreneur (pastry chef, freelancer, reseller, tailor,
 6. Set savings goals for my business or personal life
 7. Get simple, contextual financial tips that help me make better decisions
 8. Access everything offline since internet is not always available
+9. Understand what Tracklet does and how it protects local data before opening the application

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,5 +25,5 @@ See [runbooks](./runbooks/) for operational procedures.
 ## Project Status
 
 - **Version:** 0.2.0 alpha
-- **Branch:** `feat/repurpose-tracklet`
-- **State:** stabilized, buildable, and covered by automated tests
+- **Branch:** `main`
+- **State:** local-first alpha with a public landing page, buildable and covered by automated tests

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -32,6 +32,8 @@
 
 ### Experience
 
+- The public root route explains the implemented product, offline model, personal/business separation, and local-data limits before linking to the dashboard.
+- The installed PWA opens the dashboard directly; the landing page remains available at the root route.
 - The primary interface is French and formatted in FCFA.
 - Core operations work offline after the PWA shell is cached.
 - Mobile primary navigation contains four destinations; all destinations remain available in the drawer.

--- a/docs/diagrams/C4/03-component.md
+++ b/docs/diagrams/C4/03-component.md
@@ -2,7 +2,8 @@
 
 ```mermaid
 flowchart LR
-  pages[Pages and forms]
+  landing[Public landing page]
+  pages[Financial pages and forms]
   hooks[React data hooks]
   calcs[Domain calculations]
   tips[Rule-based tips]
@@ -11,6 +12,7 @@ flowchart LR
   validation[Input validation]
   db[(IndexedDB)]
 
+  landing --> pages
   pages --> hooks
   pages --> backup
   pages --> repositories

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { Sales } from "./pages/Sales";
 import { Reports } from "./pages/Reports";
 import { CashPosition } from "./pages/CashPosition";
 import { Settings } from "./pages/Settings";
+import { Landing } from "./pages/Landing";
 
 function App() {
   const [realm, setRealm] = useState<Realm>(() => {
@@ -32,19 +33,20 @@ function App() {
     <HashRouter>
       <ToastProvider>
         <Routes>
+          <Route path="/" element={<Landing />} />
           <Route element={<Layout realm={realm} onRealmChange={changeRealm} />}>
-            <Route path="/" element={<Dashboard realm={realm} />} />
+            <Route path="/dashboard" element={<Dashboard realm={realm} />} />
             <Route path="/pockets" element={<Pockets realm={realm} />} />
             <Route path="/pockets/:id" element={<PocketDetail realm={realm} />} />
             <Route path="/transactions" element={<Transactions realm={realm} />} />
-          <Route path="/debts" element={<Debts realm={realm} />} />
-          <Route path="/goals" element={<Goals realm={realm} />} />
-          <Route path="/sales" element={<Sales realm={realm} />} />
-          <Route path="/reports" element={<Reports realm={realm} />} />
-          <Route path="/cash-position" element={<CashPosition realm={realm} />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
+            <Route path="/debts" element={<Debts realm={realm} />} />
+            <Route path="/goals" element={<Goals realm={realm} />} />
+            <Route path="/sales" element={<Sales realm={realm} />} />
+            <Route path="/reports" element={<Reports realm={realm} />} />
+            <Route path="/cash-position" element={<CashPosition realm={realm} />} />
+            <Route path="/settings" element={<Settings />} />
           </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </ToastProvider>
     </HashRouter>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import type { Realm } from "../types";
 import { AgentPanel } from "./AgentPanel";
 
 const navItems = [
-  { to: "/", label: "Accueil", icon: IconDashboard },
+  { to: "/dashboard", label: "Accueil", icon: IconDashboard },
   { to: "/pockets", label: "Poches", icon: IconPockets },
   { to: "/transactions", label: "Opérations", icon: IconTransactions },
   { to: "/debts", label: "Dettes", icon: IconDebts },
@@ -26,7 +26,7 @@ export function Layout({ realm, onRealmChange }: LayoutProps) {
   const currentPage = location.pathname.replace("/", "") || "dashboard";
   const visibleNavItems = navItems.filter((item) => !item.businessOnly || realm === "business");
   const mobileNavItems = visibleNavItems.filter((item) =>
-    ["/", "/transactions", realm === "business" ? "/sales" : "/pockets", "/cash-position"].includes(item.to),
+    ["/dashboard", "/transactions", realm === "business" ? "/sales" : "/pockets", "/cash-position"].includes(item.to),
   );
 
   return (
@@ -59,7 +59,7 @@ export function Layout({ realm, onRealmChange }: LayoutProps) {
             <NavLink
               key={to}
               to={to}
-              end={to === "/"}
+              end={to === "/dashboard"}
               onClick={() => setSidebarOpen(false)}
               className={({ isActive }) =>
                 `flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
@@ -130,7 +130,7 @@ export function Layout({ realm, onRealmChange }: LayoutProps) {
             <NavLink
               key={to}
               to={to}
-              end={to === "/"}
+              end={to === "/dashboard"}
               className={({ isActive }) =>
                 `flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors ${
                   isActive

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,26 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+.landing-page {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.landing-grid {
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(rgba(0, 47, 167, 0.075) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 47, 167, 0.075) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  .landing-page * {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,10 +3,12 @@ import type { Realm } from "../types";
 import type { Transaction, CashPosition as CashPositionType } from "../types";
 import type { Insight } from "../domain/insight";
 import type { ProfitReport } from "../domain/profitability";
-import { usePocketBalances } from "../hooks/usePockets";
-import { useTransactionSummary } from "../hooks/useTransactions";
-import { useDebtSummary } from "../hooks/useDebts";
-import { getRecentTransactions } from "../domain/transaction";
+import type { PocketBalance } from "../domain/pocket";
+import type { TransactionSummary } from "../domain/transaction";
+import type { DebtSummary } from "../domain/debt";
+import { getAllBalances } from "../domain/pocket";
+import { getRecentTransactions, getTransactionSummary } from "../domain/transaction";
+import { getDebtSummary } from "../domain/debt";
 import { getAllDebts } from "../db/repositories/debt";
 import { getActivePockets } from "../db/repositories/pocket";
 import { getSales } from "../db/repositories/sale";
@@ -15,44 +17,118 @@ import { generateInsights } from "../domain/insight";
 import { getCashPosition } from "../domain/cash-position";
 import { computeProfitReport } from "../domain/profitability";
 import { EmptyState } from "../components/EmptyState";
+import { useToast } from "../components/Toast";
 import { format } from "date-fns";
 
 interface DashboardProps {
   realm: Realm;
 }
 
+interface DashboardSnapshot {
+  balances: PocketBalance[];
+  total: number;
+  summary: TransactionSummary;
+  debtSummary: DebtSummary;
+  recent: Transaction[];
+  insights: Insight[];
+  cashPosition: CashPositionType;
+  profitReport: ProfitReport;
+}
+
 export function Dashboard({ realm }: DashboardProps) {
-  const { balances, total, loading: balLoading } = usePocketBalances(realm);
-  const { summary } = useTransactionSummary(realm);
-  const debtSummary = useDebtSummary(realm);
-  const [recent, setRecent] = useState<Transaction[]>([]);
-  const [insights, setInsights] = useState<Insight[]>([]);
-  const [cashPosition, setCashPosition] = useState<CashPositionType | null>(null);
-  const [profitReport, setProfitReport] = useState<ProfitReport | null>(null);
+  const { addToast } = useToast();
+  const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
+  const [showBusy, setShowBusy] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
-    (async () => {
-      const [txns, debts, pockets, cashPos, sales, allTxns] = await Promise.all([
-        getRecentTransactions(5, realm),
-        getAllDebts(realm),
-        getActivePockets(realm),
-        getCashPosition(realm),
-        getSales({ realm }),
-        getAllTransactions({ realm }),
-      ]);
-      setRecent(txns);
-      setInsights(generateInsights(txns, pockets, debts));
-      setCashPosition(cashPos);
-      setProfitReport(computeProfitReport(sales, allTxns));
-    })();
-  }, [realm]);
+    let cancelled = false;
+    setLoadFailed(false);
+    const busyTimer = window.setTimeout(() => {
+      if (!cancelled) setShowBusy(true);
+    }, 120);
 
-  const isEmpty = !balLoading && balances.length === 0 && recent.length === 0;
+    (async () => {
+      try {
+        const [balances, summary, debtSummary, txns, debts, pockets, cashPosition, sales, allTxns] = await Promise.all([
+          getAllBalances(realm),
+          getTransactionSummary(realm),
+          getDebtSummary(realm),
+          getRecentTransactions(5, realm),
+          getAllDebts(realm),
+          getActivePockets(realm),
+          getCashPosition(realm),
+          getSales({ realm }),
+          getAllTransactions({ realm }),
+        ]);
+
+        if (cancelled) return;
+
+        setSnapshot({
+          balances,
+          total: balances.reduce((sum, balance) => sum + balance.balance, 0),
+          summary,
+          debtSummary,
+          recent: txns,
+          insights: generateInsights(txns, pockets, debts),
+          cashPosition,
+          profitReport: computeProfitReport(sales, allTxns),
+        });
+        setLoadFailed(false);
+      } catch {
+        if (cancelled) return;
+        setLoadFailed(true);
+        addToast("error", "Impossible d’actualiser la vue d’ensemble.");
+      } finally {
+        if (!cancelled) {
+          window.clearTimeout(busyTimer);
+          setShowBusy(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(busyTimer);
+      setShowBusy(false);
+    };
+  }, [realm, reloadToken, addToast]);
+
+  if (!snapshot) {
+    if (loadFailed) {
+      return (
+        <div className="space-y-6">
+          <h1 className="text-2xl font-semibold text-on-surface">Vue d’ensemble</h1>
+          <EmptyState
+            title="Vue indisponible"
+            message="Tracklet n’a pas pu lire les données locales. Réessayez dans un instant."
+            action={{ label: "Réessayer", onClick: () => setReloadToken((token) => token + 1) }}
+          />
+        </div>
+      );
+    }
+
+    return <DashboardSkeleton />;
+  }
+
+  const {
+    balances,
+    total,
+    summary,
+    debtSummary,
+    recent,
+    insights,
+    cashPosition,
+    profitReport,
+  } = snapshot;
+
+  const isEmpty = balances.length === 0 && recent.length === 0;
 
   if (isEmpty) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-semibold text-on-surface">Vue d’ensemble</h1>
+        <DashboardHeading busy={showBusy} />
         <EmptyState
           title="Bienvenue dans Tracklet"
           message="Créez une poche puis ajoutez votre première opération pour commencer."
@@ -63,31 +139,29 @@ export function Dashboard({ realm }: DashboardProps) {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-on-surface">Vue d’ensemble</h1>
+      <DashboardHeading busy={showBusy} />
 
       {/* Cash Position */}
-      {cashPosition && (
-        <div className="rounded-xl border border-border-light bg-gradient-to-br from-primary to-primary-light p-5 text-on-primary">
-          <p className="text-sm font-medium opacity-80">Trésorerie disponible</p>
-          <p className="mt-1 text-3xl font-bold">
-            {cashPosition.available.toLocaleString()} FCFA
-          </p>
-          <div className="mt-3 flex gap-6 text-xs">
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full bg-green-300" />
-              Solde : {cashPosition.totalBalance.toLocaleString()} FCFA
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full bg-amber-300" />
-              À payer : −{cashPosition.committed.toLocaleString()} FCFA
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full bg-blue-300" />
-              À recevoir : +{cashPosition.toReceive.toLocaleString()} FCFA
-            </span>
-          </div>
+      <div className="rounded-xl border border-border-light bg-gradient-to-br from-primary to-primary-light p-5 text-on-primary">
+        <p className="text-sm font-medium opacity-80">Trésorerie disponible</p>
+        <p className="mt-1 text-3xl font-bold">
+          {cashPosition.available.toLocaleString()} FCFA
+        </p>
+        <div className="mt-3 flex gap-6 text-xs">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-green-300" />
+            Solde : {cashPosition.totalBalance.toLocaleString()} FCFA
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-amber-300" />
+            À payer : −{cashPosition.committed.toLocaleString()} FCFA
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-blue-300" />
+            À recevoir : +{cashPosition.toReceive.toLocaleString()} FCFA
+          </span>
         </div>
-      )}
+      </div>
 
       {/* Summary cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -105,12 +179,12 @@ export function Dashboard({ realm }: DashboardProps) {
         />
         <Card
           label="Dettes actives"
-          value={`${debtSummary.summary.activeCount}`}
+          value={`${debtSummary.activeCount}`}
         />
       </div>
 
       {/* Profitability (when sales data exists) */}
-      {profitReport && profitReport.currentMonth.revenue > 0 && (
+      {profitReport.currentMonth.revenue > 0 && (
         <div className="rounded-xl border border-border-light bg-white p-4">
           <div className="flex items-center justify-between">
             <p className="text-sm font-semibold text-on-surface">
@@ -233,6 +307,36 @@ export function Dashboard({ realm }: DashboardProps) {
           </div>
         )}
       </section>
+    </div>
+  );
+}
+
+function DashboardHeading({ busy }: { busy: boolean }) {
+  return (
+    <div className="flex min-h-8 items-center justify-between gap-4">
+      <h1 className="text-2xl font-semibold text-on-surface">Vue d’ensemble</h1>
+      <span
+        className={`text-xs font-medium text-on-surface-muted transition-opacity ${busy ? "opacity-100" : "opacity-0"}`}
+        role="status"
+        aria-live="polite"
+      >
+        Mise à jour…
+      </span>
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6" aria-label="Chargement de la vue d’ensemble" aria-busy="true">
+      <div className="h-8 w-48 animate-pulse rounded-lg bg-surface-alt" />
+      <div className="h-36 animate-pulse rounded-xl bg-primary-container" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div key={index} className="h-24 animate-pulse rounded-xl border border-border-light bg-white" />
+        ))}
+      </div>
+      <div className="h-40 animate-pulse rounded-xl border border-border-light bg-white" />
     </div>
   );
 }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,350 @@
+import {
+  ArrowDown,
+  ArrowRight,
+  Banknote,
+  BriefcaseBusiness,
+  Check,
+  FileDown,
+  Goal,
+  HandCoins,
+  LockKeyhole,
+  ReceiptText,
+  Smartphone,
+  WalletCards,
+  WifiOff,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+
+const productFeatures = [
+  {
+    title: "Position de trésorerie",
+    description:
+      "Voyez ce qui est réellement disponible, après les dettes et engagements actifs.",
+    icon: WalletCards,
+    className: "md:col-span-2 md:row-span-2",
+    content: (
+      <div className="mt-8 border-t border-[#002FA7]">
+        {["Espèces", "Mobile Money", "Caisse activité"].map((pocket) => (
+          <div
+            key={pocket}
+            className="flex items-center justify-between border-b border-black/15 py-3 text-sm"
+          >
+            <span>{pocket}</span>
+            <span className="font-medium text-[#002FA7]">Solde calculé</span>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+  {
+    title: "Transferts fiables",
+    description: "Un débit et un crédit liés, enregistrés ensemble entre deux poches.",
+    icon: ArrowRight,
+    content: (
+      <div className="mt-8 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.16em]">
+        <span>Poche A</span>
+        <ArrowRight aria-hidden="true" className="h-4 w-4 text-[#002FA7]" />
+        <span>Poche B</span>
+      </div>
+    ),
+  },
+  {
+    title: "Ventes reliées au cash",
+    description: "Chaque vente crédite automatiquement la poche professionnelle choisie.",
+    icon: ReceiptText,
+    content: (
+      <ol className="mt-7 flex flex-wrap items-center gap-2 text-xs font-medium">
+        <li className="border border-black px-2 py-1">Vente</li>
+        <li aria-hidden="true"><ArrowRight className="h-4 w-4 text-[#002FA7]" /></li>
+        <li className="border border-black px-2 py-1">Revenu</li>
+        <li aria-hidden="true"><ArrowRight className="h-4 w-4 text-[#002FA7]" /></li>
+        <li className="border border-black px-2 py-1">Poche</li>
+      </ol>
+    ),
+  },
+  {
+    title: "Dettes et créances",
+    description: "Suivez ce que vous devez et ce que l’on vous doit, jusqu’au règlement.",
+    icon: HandCoins,
+  },
+  {
+    title: "Objectifs d’épargne",
+    description: "Mesurez votre progression sans modifier artificiellement le solde des poches.",
+    icon: Goal,
+  },
+  {
+    title: "Rapports exportables",
+    description: "Filtrez vos périodes et exportez un CSV quand vous en avez besoin.",
+    icon: FileDown,
+  },
+];
+
+function scrollToSection(id: string) {
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  document.getElementById(id)?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "start" });
+}
+
+export function Landing() {
+  return (
+    <div className="landing-page min-h-svh bg-white text-[#090909]">
+      <a
+        href="#landing-main"
+        onClick={(event) => {
+          event.preventDefault();
+          document.getElementById("landing-main")?.focus();
+        }}
+        className="fixed left-3 top-3 z-[60] -translate-y-24 bg-[#002FA7] px-4 py-3 text-sm font-semibold text-white focus:translate-y-0"
+      >
+        Aller au contenu
+      </a>
+
+      <header className="sticky top-0 z-50 border-b border-black/20 bg-white">
+        <div className="mx-auto flex h-16 max-w-[1440px] items-center justify-between px-5 sm:px-8 lg:px-12">
+          <Link to="/" className="flex items-center gap-3" aria-label="Tracklet — accueil">
+            <span className="grid h-8 w-8 place-items-center bg-[#002FA7] text-sm font-bold text-white">T</span>
+            <span className="text-lg font-bold tracking-[-0.03em]">Tracklet</span>
+          </Link>
+
+          <nav className="hidden items-center gap-8 text-sm font-medium md:flex" aria-label="Navigation principale">
+            <button type="button" onClick={() => scrollToSection("fonctionnement")} className="hover:text-[#002FA7]">
+              Fonctionnement
+            </button>
+            <button type="button" onClick={() => scrollToSection("produit")} className="hover:text-[#002FA7]">
+              Produit
+            </button>
+            <button type="button" onClick={() => scrollToSection("confidentialite")} className="hover:text-[#002FA7]">
+              Confidentialité
+            </button>
+          </nav>
+
+          <Link
+            to="/dashboard"
+            className="inline-flex items-center gap-2 bg-[#002FA7] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#002FA7]"
+          >
+            Ouvrir Tracklet
+            <ArrowRight aria-hidden="true" className="h-4 w-4" />
+          </Link>
+        </div>
+      </header>
+
+      <main id="landing-main" tabIndex={-1}>
+        <section className="landing-grid border-b border-black/20">
+          <div className="mx-auto grid min-h-[calc(100svh-4rem)] max-w-[1440px] lg:grid-cols-[1.05fr_0.95fr]">
+            <div className="flex flex-col justify-between border-black/20 px-5 py-14 sm:px-8 sm:py-20 lg:border-r lg:px-12 lg:py-24">
+              <div>
+                <p className="mb-8 inline-flex items-center gap-2 border border-[#002FA7] bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-[#002FA7]">
+                  <WifiOff aria-hidden="true" className="h-4 w-4" />
+                  Finance locale · FCFA · hors ligne
+                </p>
+                <h1 className="max-w-4xl text-[clamp(3.5rem,8.5vw,8.6rem)] font-bold leading-[0.86] tracking-[-0.075em]">
+                  Votre argent perso.
+                  <span className="block text-[#002FA7]">Votre activité.</span>
+                  <span className="block">Enfin séparés.</span>
+                </h1>
+              </div>
+
+              <div className="mt-14 grid gap-8 border-t border-black pt-7 sm:grid-cols-[1fr_auto] sm:items-end">
+                <p className="max-w-xl text-lg leading-relaxed text-black/65 sm:text-xl">
+                  Tracklet rassemble vos poches, ventes, dettes et objectifs dans une vue claire—sur votre appareil, même sans connexion.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => scrollToSection("fonctionnement")}
+                  className="inline-flex items-center gap-2 text-sm font-semibold text-[#002FA7] hover:text-black"
+                >
+                  Découvrir
+                  <ArrowDown aria-hidden="true" className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            <div className="flex items-center bg-[#F7F7F8] px-5 py-14 sm:px-8 lg:px-12">
+              <div className="w-full border border-black bg-white">
+                <div className="flex items-center justify-between border-b border-black px-5 py-4">
+                  <span className="text-xs font-bold uppercase tracking-[0.18em]">Position de trésorerie</span>
+                  <span className="h-2.5 w-2.5 bg-[#002FA7]" aria-hidden="true" />
+                </div>
+
+                <div className="grid sm:grid-cols-2">
+                  <div className="border-b border-black p-5 sm:border-b-0 sm:border-r">
+                    <div className="mb-8 flex items-center justify-between">
+                      <span className="text-sm font-semibold">Personnel</span>
+                      <Smartphone aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
+                    </div>
+                    <div className="space-y-3">
+                      <div className="border-t border-black/20 pt-3 text-sm">Espèces</div>
+                      <div className="border-t border-black/20 pt-3 text-sm">Mobile Money</div>
+                    </div>
+                  </div>
+                  <div className="p-5">
+                    <div className="mb-8 flex items-center justify-between">
+                      <span className="text-sm font-semibold">Activité</span>
+                      <BriefcaseBusiness aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
+                    </div>
+                    <div className="space-y-3">
+                      <div className="border-t border-black/20 pt-3 text-sm">Caisse</div>
+                      <div className="border-t border-black/20 pt-3 text-sm">Mobile Money Pro</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="border-t border-[#002FA7] bg-[#002FA7] p-6 text-white">
+                  <div className="mb-8 flex items-start justify-between gap-6">
+                    <p className="max-w-xs text-sm leading-relaxed text-white/75">
+                      Deux espaces distincts. Une lecture honnête de ce qui est disponible.
+                    </p>
+                    <Banknote aria-hidden="true" className="h-7 w-7 shrink-0" />
+                  </div>
+                  <p className="text-2xl font-bold tracking-[-0.04em] sm:text-3xl">Calculé en FCFA</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section aria-label="Principes du produit" className="border-b border-black/20">
+          <div className="mx-auto grid max-w-[1440px] grid-cols-2 md:grid-cols-4">
+            {[
+              [WifiOff, "Hors ligne par défaut"],
+              [LockKeyhole, "Sans compte obligatoire"],
+              [Banknote, "Pensé pour le FCFA"],
+              [Smartphone, "Données sur votre appareil"],
+            ].map(([Icon, label], index) => {
+              const PrincipleIcon = Icon as typeof WifiOff;
+              return (
+                <div
+                  key={label as string}
+                  className={`flex min-h-32 flex-col justify-between gap-5 p-5 sm:p-7 ${
+                    index % 2 === 0 ? "border-r" : ""
+                  } ${index < 2 ? "border-b md:border-b-0" : ""} md:border-r md:last:border-r-0 border-black/20`}
+                >
+                  <PrincipleIcon aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
+                  <p className="max-w-[12rem] text-sm font-semibold">{label as string}</p>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section id="fonctionnement" className="scroll-mt-20 border-b border-black/20 bg-white">
+          <div className="mx-auto max-w-[1440px] px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
+            <div className="grid gap-10 lg:grid-cols-[0.75fr_1.25fr]">
+              <div>
+                <p className="mb-5 text-sm font-semibold text-[#002FA7]">Une méthode simple</p>
+                <h2 className="max-w-md text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
+                  Le même téléphone. Deux réalités financières.
+                </h2>
+              </div>
+              <p className="max-w-2xl self-end text-lg leading-relaxed text-black/60 sm:text-xl">
+                Tracklet ne transforme pas votre quotidien en logiciel comptable. Il vous aide à enregistrer les mouvements essentiels et à garder l’argent personnel séparé de l’activité.
+              </p>
+            </div>
+
+            <ol className="mt-16 grid border-l border-t border-black md:grid-cols-3">
+              {[
+                ["01", "Séparez", "Créez vos poches personnelles et professionnelles."],
+                ["02", "Enregistrez", "Ajoutez revenus, dépenses, transferts, ventes et dettes."],
+                ["03", "Comprenez", "Lisez votre trésorerie, vos rapports et vos objectifs."],
+              ].map(([number, title, copy]) => (
+                <li key={number} className="border-b border-r border-black p-6 sm:p-8">
+                  <span className="block text-7xl font-bold leading-none tracking-[-0.08em] text-[#002FA7] sm:text-8xl">{number}</span>
+                  <h3 className="mt-10 text-2xl font-bold tracking-[-0.04em]">{title}</h3>
+                  <p className="mt-3 max-w-xs leading-relaxed text-black/60">{copy}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section id="produit" className="scroll-mt-20 border-b border-black/20 bg-[#F7F7F8]">
+          <div className="mx-auto max-w-[1440px] px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
+            <div className="mb-14 flex flex-col justify-between gap-6 border-b border-black pb-8 md:flex-row md:items-end">
+              <h2 className="max-w-3xl text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
+                Les outils qui suivent vraiment votre cash.
+              </h2>
+              <p className="max-w-sm text-base leading-relaxed text-black/60">
+                Pas de données décoratives : chaque écran répond à une décision financière concrète.
+              </p>
+            </div>
+
+            <ul className="grid auto-rows-auto border-l border-t border-black md:grid-cols-2 lg:grid-cols-3">
+              {productFeatures.map(({ title, description, icon: Icon, className = "", content }) => (
+                <li key={title} className={`min-h-72 border-b border-r border-black bg-white p-6 sm:p-8 ${className}`}>
+                  <div className="flex items-start justify-between gap-6">
+                    <div>
+                      <h3 className="text-2xl font-bold tracking-[-0.04em]">{title}</h3>
+                      <p className="mt-3 max-w-md leading-relaxed text-black/60">{description}</p>
+                    </div>
+                    <Icon aria-hidden="true" className="h-6 w-6 shrink-0 text-[#002FA7]" />
+                  </div>
+                  {content}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section id="confidentialite" className="scroll-mt-20 bg-[#002FA7] text-white">
+          <div className="mx-auto grid max-w-[1440px] lg:grid-cols-2">
+            <div className="border-white/35 px-5 py-20 sm:px-8 lg:border-r lg:px-12 lg:py-28">
+              <LockKeyhole aria-hidden="true" className="mb-12 h-9 w-9" />
+              <h2 className="max-w-2xl text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
+                Vos chiffres restent là où ils servent : chez vous.
+              </h2>
+            </div>
+            <div className="flex flex-col justify-between px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
+              <p className="max-w-xl text-lg leading-relaxed text-white/75 sm:text-xl">
+                Les données financières sont stockées dans le navigateur. Tracklet n’exige ni compte, ni serveur, ni synchronisation cloud pour fonctionner.
+              </p>
+              <ul className="mt-14 border-t border-white/45">
+                {[
+                  "Stockage local avec IndexedDB",
+                  "Sauvegarde JSON exportable et restaurable",
+                  "Aucune télémétrie financière",
+                  "Exports à conserver comme des documents sensibles",
+                ].map((item) => (
+                  <li key={item} className="flex items-center gap-3 border-b border-white/45 py-4 text-sm font-medium">
+                    <Check aria-hidden="true" className="h-4 w-4 shrink-0" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="landing-grid border-b border-black/20">
+          <div className="mx-auto flex max-w-[1440px] flex-col items-start justify-between gap-12 px-5 py-20 sm:px-8 lg:flex-row lg:items-end lg:px-12 lg:py-28">
+            <div>
+              <p className="mb-6 text-sm font-semibold text-[#002FA7]">Prêt sur ce navigateur</p>
+              <h2 className="max-w-4xl text-5xl font-bold leading-[0.9] tracking-[-0.065em] sm:text-7xl lg:text-8xl">
+                Commencez par une poche. Voyez enfin l’ensemble.
+              </h2>
+            </div>
+            <Link
+              to="/dashboard"
+              className="inline-flex shrink-0 items-center gap-3 bg-[#002FA7] px-6 py-4 text-base font-semibold text-white transition-colors hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#002FA7]"
+            >
+              Ouvrir l’application
+              <ArrowRight aria-hidden="true" className="h-5 w-5" />
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-black/20 bg-white text-black">
+        <div className="mx-auto flex max-w-[1440px] flex-col justify-between gap-8 px-5 py-10 sm:px-8 md:flex-row md:items-end lg:px-12">
+          <div>
+            <p className="text-2xl font-bold tracking-[-0.04em]">Tracklet</p>
+            <p className="mt-2 max-w-sm text-sm text-black/55">Copilote financier local pour les micro-entrepreneurs francophones.</p>
+          </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-3 text-sm text-black/65">
+            <button type="button" onClick={() => scrollToSection("produit")} className="hover:text-[#002FA7]">Produit</button>
+            <button type="button" onClick={() => scrollToSection("confidentialite")} className="hover:text-[#002FA7]">Confidentialité</button>
+            <Link to="/dashboard" className="hover:text-[#002FA7]">Application</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
         background_color: "#FAFBFC",
         display: "standalone",
         orientation: "portrait",
-        start_url: ".",
+        start_url: "./#/dashboard",
         scope: ".",
         icons: [
           {


### PR DESCRIPTION
## Summary

- Add a public French landing page at `/#/` with a deliberate Swiss editorial direction: white surfaces, visible grid, one blue accent, asymmetric typography, and no fabricated metrics or testimonials.
- Present only implemented Tracklet capabilities: personal/business separation, pockets, transfers, linked sales, debts, goals, reports, local storage, and backup limits.
- Move the financial dashboard to `/#/dashboard` while keeping existing financial routes stable.
- Open installed PWA sessions directly on the dashboard through the manifest start URL.
- Align README, PRD, SRS, architecture, C4, and design-system documentation with the new public/product route split.

## Design research

- Adapt the product-mockup hero pattern from 21st.dev’s Financial Hero Section without importing its animation layer.
- Follow 21st.dev’s bento guidance: six real features, one deliberately dominant cell, semantic list markup, and a mobile-first order instead of shrinking the desktop grid.
- Keep the implementation dependency-free beyond the existing React, Tailwind, and Lucide stack.

## Validation

- `npm run check` — lint, 15 tests, TypeScript, and production PWA build pass.
- `npm audit` — 0 known vulnerabilities.
- Production manifest verified with `./#/dashboard` as `start_url`.
- All 19 Markdown files have valid local links.
- Development server smoke-tested with the landing module and French product copy served successfully.