### PR TITLE
Redesign Tracklet landing with a distinct organic UX

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -211,16 +211,17 @@ The aesthetic draws from modern fintech apps (Revolut, Chime) adapted to the loc
 
 ## Public landing direction
 
-The public landing page uses a Swiss editorial system distinct from the operational app shell. Its purpose is explanation and orientation, not financial data entry.
+The public landing page uses an organic visual system distinct from conventional blue fintech marketing. Its purpose is explanation and orientation, not financial data entry.
 
-- **Surface:** pure white (`#FFFFFF`) and neutral (`#F7F7F8`).
-- **Accent:** Yves Klein blue (`#002FA7`) only.
-- **Typography:** Helvetica Neue or a system Helvetica/Arial fallback, left aligned with tightly tracked display headings.
-- **Structure:** asymmetric sections, visible 1px grid lines, square controls, and large numerals as composition elements.
-- **Restrictions:** no gradients, grain, decorative shadows, fabricated balances, customer counts, or testimonials.
-- **Signature motif:** personal and business pockets remain visibly separated before converging into one cash-position explanation.
+- **Surface:** sand (`#E8DCC7`) and oat (`#D4B895`). Pure white and cold grey are excluded.
+- **Palette:** deep moss (`#465024`) for accessible text and controls, sage (`#8B9D83`), clay (`#B08B6E`), ochre (`#C08E3A`), terracotta (`#C66B3D`), and soft terracotta (`#D98E69`) for large surfaces.
+- **Typography:** Epilogue Variable, bundled with the application for offline use.
+- **Structure:** rounded 16–32px containers, generous reading space, large left-aligned headings, and one primary action repeated consistently.
+- **Texture and motion:** 2.5% SVG grain plus a single 500ms hero arrival; reduced-motion preferences disable it.
+- **Restrictions:** no blue fintech palette, chapter numbering, bento wall, fabricated balances, customer counts, or testimonials.
+- **Signature motif:** personal and business money follow separate curved streams before converging into the cash-position explanation.
 
-The product mockup on the landing names real Tracklet concepts but never pretends that sample balances are user data. Once the user opens `/#/dashboard`, the operational interface returns to the mobile-first tokens documented below.
+The landing organizes content around three user outcomes and progressively disclosed questions. All controls meet at least a 44px touch target, focus remains visible, and the mobile navigation exposes every section. Once the user opens `/#/dashboard`, the operational interface returns to the mobile-first tokens documented below.
 
 ## Colors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tracklet",
       "version": "0.2.0",
       "dependencies": {
+        "@fontsource-variable/epilogue": "^5.3.0",
         "date-fns": "^4.4.0",
         "idb": "^8.0.3",
         "lucide-react": "^1.22.0",
@@ -1558,6 +1559,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/epilogue": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/epilogue/-/epilogue-5.3.0.tgz",
+      "integrity": "sha512-atoQ7bIqgDLX+zlxbxmYpNZ7nqkwwZczkhJhWdaX+UBZufhPWP3vrcKaLVaNcCbRyHeSoX/y/HJNGjKhewEsAg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource-variable/epilogue": "^5.3.0",
     "date-fns": "^4.4.0",
     "idb": "^8.0.3",
     "lucide-react": "^1.22.0",

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+@font-face {
+  font-family: "Epilogue Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("@fontsource-variable/epilogue/files/epilogue-latin-wght-normal.woff2") format("woff2-variations");
+}
+
 @theme {
   --color-primary: #185FA5;
   --color-primary-light: #378ADD;
@@ -67,16 +75,42 @@ body {
   flex-direction: column;
 }
 
-.landing-page {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+.landing-organic {
+  position: relative;
+  isolation: isolate;
+  font-family: "Epilogue Variable", Epilogue, system-ui, sans-serif;
 }
 
-.landing-grid {
-  background-color: #ffffff;
-  background-image:
-    linear-gradient(rgba(0, 47, 167, 0.075) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 47, 167, 0.075) 1px, transparent 1px);
-  background-size: 48px 48px;
+.landing-organic::before {
+  position: fixed;
+  z-index: 60;
+  inset: 0;
+  content: "";
+  pointer-events: none;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='.35'/%3E%3C/svg%3E");
+  mix-blend-mode: multiply;
+}
+
+.landing-organic :focus-visible {
+  outline: 3px solid #e8dcc7;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 6px #30351f;
+}
+
+.organic-breathe {
+  animation: organic-arrive 500ms ease-out both;
+}
+
+@keyframes organic-arrive {
+  from {
+    opacity: 0.88;
+    transform: translateY(10px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -84,7 +118,10 @@ body {
     scroll-behavior: auto;
   }
 
-  .landing-page * {
+  .landing-organic *,
+  .organic-breathe {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,81 +1,60 @@
+import { useEffect, useRef, useState } from "react";
 import {
-  ArrowDown,
   ArrowRight,
   Banknote,
   BriefcaseBusiness,
   Check,
+  ChevronDown,
   FileDown,
-  Goal,
   HandCoins,
+  Leaf,
   LockKeyhole,
+  Menu,
   ReceiptText,
   Smartphone,
   WalletCards,
-  WifiOff,
+  X,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 
-const productFeatures = [
+const outcomes = [
   {
-    title: "Position de trésorerie",
-    description:
-      "Voyez ce qui est réellement disponible, après les dettes et engagements actifs.",
     icon: WalletCards,
-    className: "md:col-span-2 md:row-span-2",
-    content: (
-      <div className="mt-8 border-t border-[#002FA7]">
-        {["Espèces", "Mobile Money", "Caisse activité"].map((pocket) => (
-          <div
-            key={pocket}
-            className="flex items-center justify-between border-b border-black/15 py-3 text-sm"
-          >
-            <span>{pocket}</span>
-            <span className="font-medium text-[#002FA7]">Solde calculé</span>
-          </div>
-        ))}
-      </div>
-    ),
+    title: "Ce que vous pouvez utiliser",
+    description: "Tracklet calcule la trésorerie disponible à partir des poches, dettes et créances actives.",
   },
   {
-    title: "Transferts fiables",
-    description: "Un débit et un crédit liés, enregistrés ensemble entre deux poches.",
-    icon: ArrowRight,
-    content: (
-      <div className="mt-8 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.16em]">
-        <span>Poche A</span>
-        <ArrowRight aria-hidden="true" className="h-4 w-4 text-[#002FA7]" />
-        <span>Poche B</span>
-      </div>
-    ),
-  },
-  {
-    title: "Ventes reliées au cash",
-    description: "Chaque vente crédite automatiquement la poche professionnelle choisie.",
     icon: ReceiptText,
-    content: (
-      <ol className="mt-7 flex flex-wrap items-center gap-2 text-xs font-medium">
-        <li className="border border-black px-2 py-1">Vente</li>
-        <li aria-hidden="true"><ArrowRight className="h-4 w-4 text-[#002FA7]" /></li>
-        <li className="border border-black px-2 py-1">Revenu</li>
-        <li aria-hidden="true"><ArrowRight className="h-4 w-4 text-[#002FA7]" /></li>
-        <li className="border border-black px-2 py-1">Poche</li>
-      </ol>
-    ),
+    title: "Ce que l’activité rapporte",
+    description: "Les ventes créditent la bonne poche et sont comparées aux dépenses professionnelles.",
   },
   {
-    title: "Dettes et créances",
-    description: "Suivez ce que vous devez et ce que l’on vous doit, jusqu’au règlement.",
     icon: HandCoins,
+    title: "Ce qui doit encore bouger",
+    description: "Les sommes à payer et à recevoir restent visibles jusqu’à leur règlement.",
+  },
+];
+
+const answers = [
+  {
+    question: "Combien puis-je réellement utiliser ?",
+    answer: "La position de trésorerie réunit les soldes de vos poches, retire les engagements actifs et ajoute les créances attendues.",
+    items: ["Espèces et Mobile Money", "Poches séparées par espace", "Transferts enregistrés des deux côtés"],
   },
   {
-    title: "Objectifs d’épargne",
-    description: "Mesurez votre progression sans modifier artificiellement le solde des poches.",
-    icon: Goal,
+    question: "Mon activité gagne-t-elle de l’argent ?",
+    answer: "Les ventes et les dépenses professionnelles alimentent un résultat mensuel lisible, sans mélanger les dépenses personnelles.",
+    items: ["Ventes liées à une poche", "Dépenses professionnelles", "Résultat et marge du mois"],
   },
   {
-    title: "Rapports exportables",
-    description: "Filtrez vos périodes et exportez un CSV quand vous en avez besoin.",
-    icon: FileDown,
+    question: "Qu’est-ce qui doit entrer ou sortir ?",
+    answer: "Les dettes et créances actives restent dans votre vue de trésorerie jusqu’à ce qu’elles soient réglées ou abandonnées.",
+    items: ["Sommes empruntées", "Sommes prêtées", "Statuts de règlement"],
+  },
+  {
+    question: "Comment garder mes données ?",
+    answer: "Vos données vivent dans ce navigateur. Une sauvegarde JSON permet de les restaurer et les rapports peuvent être exportés en CSV.",
+    items: ["Sauvegarde complète", "Restauration confirmée", "Exports CSV par période"],
   },
 ];
 
@@ -85,226 +64,237 @@ function scrollToSection(id: string) {
 }
 
 export function Landing() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [openAnswer, setOpenAnswer] = useState<number | null>(0);
+  const menuButton = useRef<HTMLButtonElement>(null);
+  const firstMenuItem = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    firstMenuItem.current?.focus();
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+        window.requestAnimationFrame(() => menuButton.current?.focus());
+      }
+    };
+
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [menuOpen]);
+
+  const goTo = (id: string) => {
+    setMenuOpen(false);
+    window.requestAnimationFrame(() => scrollToSection(id));
+  };
+
   return (
-    <div className="landing-page min-h-svh bg-white text-[#090909]">
+    <div className="landing-organic min-h-svh bg-[#E8DCC7] text-[#30351F]">
       <a
         href="#landing-main"
         onClick={(event) => {
           event.preventDefault();
           document.getElementById("landing-main")?.focus();
         }}
-        className="fixed left-3 top-3 z-[60] -translate-y-24 bg-[#002FA7] px-4 py-3 text-sm font-semibold text-white focus:translate-y-0"
+        className="fixed left-3 top-3 z-[70] -translate-y-24 rounded-2xl bg-[#465024] px-4 py-3 text-sm font-semibold text-[#E8DCC7] focus:translate-y-0"
       >
         Aller au contenu
       </a>
 
-      <header className="sticky top-0 z-50 border-b border-black/20 bg-white">
-        <div className="mx-auto flex h-16 max-w-[1440px] items-center justify-between px-5 sm:px-8 lg:px-12">
-          <Link to="/" className="flex items-center gap-3" aria-label="Tracklet — accueil">
-            <span className="grid h-8 w-8 place-items-center bg-[#002FA7] text-sm font-bold text-white">T</span>
-            <span className="text-lg font-bold tracking-[-0.03em]">Tracklet</span>
+      <header className="sticky top-0 z-50 border-b border-[#465024]/25 bg-[#E8DCC7]">
+        <div className="mx-auto flex min-h-18 max-w-7xl items-center justify-between gap-4 px-5 sm:px-8 lg:px-10">
+          <Link to="/" className="flex min-h-11 items-center gap-3" aria-label="Tracklet — accueil">
+            <span className="grid h-10 w-10 place-items-center rounded-2xl bg-[#465024] font-bold text-[#E8DCC7]">T</span>
+            <span className="text-lg font-bold tracking-[-0.04em]">Tracklet</span>
           </Link>
 
-          <nav className="hidden items-center gap-8 text-sm font-medium md:flex" aria-label="Navigation principale">
-            <button type="button" onClick={() => scrollToSection("fonctionnement")} className="hover:text-[#002FA7]">
+          <nav className="hidden items-center gap-2 lg:flex" aria-label="Navigation principale">
+            <button type="button" onClick={() => goTo("pourquoi")} className="min-h-11 rounded-2xl px-4 text-sm font-medium hover:bg-[#D4B895]">
+              Ce que ça clarifie
+            </button>
+            <button type="button" onClick={() => goTo("fonctionnement")} className="min-h-11 rounded-2xl px-4 text-sm font-medium hover:bg-[#D4B895]">
               Fonctionnement
             </button>
-            <button type="button" onClick={() => scrollToSection("produit")} className="hover:text-[#002FA7]">
-              Produit
+            <button type="button" onClick={() => goTo("confidentialite")} className="min-h-11 rounded-2xl px-4 text-sm font-medium hover:bg-[#D4B895]">
+              Données locales
             </button>
-            <button type="button" onClick={() => scrollToSection("confidentialite")} className="hover:text-[#002FA7]">
-              Confidentialité
-            </button>
+            <Link to="/dashboard" className="ml-2 inline-flex min-h-11 items-center gap-2 rounded-2xl bg-[#465024] px-5 text-sm font-semibold text-[#E8DCC7] transition-colors duration-300 hover:bg-[#30351F]">
+              Ouvrir Tracklet
+              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
           </nav>
 
-          <Link
-            to="/dashboard"
-            className="inline-flex items-center gap-2 bg-[#002FA7] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#002FA7]"
+          <button
+            ref={menuButton}
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            className="grid h-11 w-11 place-items-center rounded-2xl border border-[#465024]/40 lg:hidden"
+            aria-label={menuOpen ? "Fermer le menu" : "Ouvrir le menu"}
+            aria-expanded={menuOpen}
+            aria-controls="landing-mobile-menu"
           >
-            Ouvrir Tracklet
-            <ArrowRight aria-hidden="true" className="h-4 w-4" />
-          </Link>
+            {menuOpen ? <X aria-hidden="true" className="h-5 w-5" /> : <Menu aria-hidden="true" className="h-5 w-5" />}
+          </button>
         </div>
+
+        {menuOpen && (
+          <nav id="landing-mobile-menu" aria-label="Navigation mobile" className="border-t border-[#465024]/25 bg-[#E8DCC7] px-5 py-4 lg:hidden">
+            <div className="mx-auto grid max-w-7xl gap-2">
+              <button ref={firstMenuItem} type="button" onClick={() => goTo("pourquoi")} className="min-h-12 rounded-2xl px-4 text-left font-medium hover:bg-[#D4B895]">
+                Ce que ça clarifie
+              </button>
+              <button type="button" onClick={() => goTo("fonctionnement")} className="min-h-12 rounded-2xl px-4 text-left font-medium hover:bg-[#D4B895]">
+                Fonctionnement
+              </button>
+              <button type="button" onClick={() => goTo("confidentialite")} className="min-h-12 rounded-2xl px-4 text-left font-medium hover:bg-[#D4B895]">
+                Données locales
+              </button>
+              <Link to="/dashboard" onClick={() => setMenuOpen(false)} className="mt-2 inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-[#465024] px-5 font-semibold text-[#E8DCC7]">
+                Ouvrir Tracklet
+                <ArrowRight aria-hidden="true" className="h-4 w-4" />
+              </Link>
+            </div>
+          </nav>
+        )}
       </header>
 
       <main id="landing-main" tabIndex={-1}>
-        <section className="landing-grid border-b border-black/20">
-          <div className="mx-auto grid min-h-[calc(100svh-4rem)] max-w-[1440px] lg:grid-cols-[1.05fr_0.95fr]">
-            <div className="flex flex-col justify-between border-black/20 px-5 py-14 sm:px-8 sm:py-20 lg:border-r lg:px-12 lg:py-24">
-              <div>
-                <p className="mb-8 inline-flex items-center gap-2 border border-[#002FA7] bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-[#002FA7]">
-                  <WifiOff aria-hidden="true" className="h-4 w-4" />
-                  Finance locale · FCFA · hors ligne
-                </p>
-                <h1 className="max-w-4xl text-[clamp(3.5rem,8.5vw,8.6rem)] font-bold leading-[0.86] tracking-[-0.075em]">
-                  Votre argent perso.
-                  <span className="block text-[#002FA7]">Votre activité.</span>
-                  <span className="block">Enfin séparés.</span>
-                </h1>
-              </div>
+        <section className="overflow-hidden px-5 pb-20 pt-14 sm:px-8 sm:pb-28 sm:pt-20 lg:px-10">
+          <div className="mx-auto grid max-w-7xl items-center gap-16 lg:grid-cols-[1.04fr_0.96fr]">
+            <div>
+              <p className="mb-6 max-w-max rounded-2xl bg-[#D4B895] px-4 py-2 text-sm font-semibold text-[#465024]">
+                Pour le foyer et la petite activité
+              </p>
+              <h1 className="max-w-3xl text-[clamp(3.2rem,7vw,7.4rem)] font-bold leading-[0.92] tracking-[-0.07em]">
+                Votre argent personnel n’est pas la caisse de votre activité.
+              </h1>
+              <p className="mt-8 max-w-2xl text-lg leading-relaxed text-[#30351F]/75 sm:text-xl">
+                Tracklet vous aide à séparer les deux, enregistrer chaque mouvement et savoir ce que vous pouvez réellement utiliser—en FCFA, même hors ligne.
+              </p>
 
-              <div className="mt-14 grid gap-8 border-t border-black pt-7 sm:grid-cols-[1fr_auto] sm:items-end">
-                <p className="max-w-xl text-lg leading-relaxed text-black/65 sm:text-xl">
-                  Tracklet rassemble vos poches, ventes, dettes et objectifs dans une vue claire—sur votre appareil, même sans connexion.
-                </p>
-                <button
-                  type="button"
-                  onClick={() => scrollToSection("fonctionnement")}
-                  className="inline-flex items-center gap-2 text-sm font-semibold text-[#002FA7] hover:text-black"
-                >
-                  Découvrir
-                  <ArrowDown aria-hidden="true" className="h-4 w-4" />
+              <div className="mt-9 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+                <Link to="/dashboard" className="inline-flex min-h-13 items-center gap-3 rounded-2xl bg-[#465024] px-6 font-semibold text-[#E8DCC7] transition-colors duration-300 hover:bg-[#30351F]">
+                  Ouvrir Tracklet
+                  <ArrowRight aria-hidden="true" className="h-5 w-5" />
+                </Link>
+                <button type="button" onClick={() => goTo("fonctionnement")} className="min-h-12 rounded-2xl px-4 font-semibold text-[#465024] underline decoration-[#465024]/35 underline-offset-4 hover:decoration-[#465024]">
+                  Voir comment ça fonctionne
                 </button>
               </div>
+
+              <ul className="mt-10 flex flex-wrap gap-x-6 gap-y-3 text-sm font-medium text-[#30351F]/75" aria-label="Caractéristiques principales">
+                {["Sans compte", "Données locales", "Montants en FCFA"].map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <Check aria-hidden="true" className="h-4 w-4 text-[#465024]" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
             </div>
 
-            <div className="flex items-center bg-[#F7F7F8] px-5 py-14 sm:px-8 lg:px-12">
-              <div className="w-full border border-black bg-white">
-                <div className="flex items-center justify-between border-b border-black px-5 py-4">
-                  <span className="text-xs font-bold uppercase tracking-[0.18em]">Position de trésorerie</span>
-                  <span className="h-2.5 w-2.5 bg-[#002FA7]" aria-hidden="true" />
-                </div>
-
-                <div className="grid sm:grid-cols-2">
-                  <div className="border-b border-black p-5 sm:border-b-0 sm:border-r">
-                    <div className="mb-8 flex items-center justify-between">
-                      <span className="text-sm font-semibold">Personnel</span>
-                      <Smartphone aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
-                    </div>
-                    <div className="space-y-3">
-                      <div className="border-t border-black/20 pt-3 text-sm">Espèces</div>
-                      <div className="border-t border-black/20 pt-3 text-sm">Mobile Money</div>
-                    </div>
-                  </div>
-                  <div className="p-5">
-                    <div className="mb-8 flex items-center justify-between">
-                      <span className="text-sm font-semibold">Activité</span>
-                      <BriefcaseBusiness aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
-                    </div>
-                    <div className="space-y-3">
-                      <div className="border-t border-black/20 pt-3 text-sm">Caisse</div>
-                      <div className="border-t border-black/20 pt-3 text-sm">Mobile Money Pro</div>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="border-t border-[#002FA7] bg-[#002FA7] p-6 text-white">
-                  <div className="mb-8 flex items-start justify-between gap-6">
-                    <p className="max-w-xs text-sm leading-relaxed text-white/75">
-                      Deux espaces distincts. Une lecture honnête de ce qui est disponible.
-                    </p>
-                    <Banknote aria-hidden="true" className="h-7 w-7 shrink-0" />
-                  </div>
-                  <p className="text-2xl font-bold tracking-[-0.04em] sm:text-3xl">Calculé en FCFA</p>
-                </div>
-              </div>
-            </div>
+            <MoneyFlow />
           </div>
         </section>
 
-        <section aria-label="Principes du produit" className="border-b border-black/20">
-          <div className="mx-auto grid max-w-[1440px] grid-cols-2 md:grid-cols-4">
-            {[
-              [WifiOff, "Hors ligne par défaut"],
-              [LockKeyhole, "Sans compte obligatoire"],
-              [Banknote, "Pensé pour le FCFA"],
-              [Smartphone, "Données sur votre appareil"],
-            ].map(([Icon, label], index) => {
-              const PrincipleIcon = Icon as typeof WifiOff;
-              return (
-                <div
-                  key={label as string}
-                  className={`flex min-h-32 flex-col justify-between gap-5 p-5 sm:p-7 ${
-                    index % 2 === 0 ? "border-r" : ""
-                  } ${index < 2 ? "border-b md:border-b-0" : ""} md:border-r md:last:border-r-0 border-black/20`}
-                >
-                  <PrincipleIcon aria-hidden="true" className="h-5 w-5 text-[#002FA7]" />
-                  <p className="max-w-[12rem] text-sm font-semibold">{label as string}</p>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        <section id="fonctionnement" className="scroll-mt-20 border-b border-black/20 bg-white">
-          <div className="mx-auto max-w-[1440px] px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
-            <div className="grid gap-10 lg:grid-cols-[0.75fr_1.25fr]">
-              <div>
-                <p className="mb-5 text-sm font-semibold text-[#002FA7]">Une méthode simple</p>
-                <h2 className="max-w-md text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
-                  Le même téléphone. Deux réalités financières.
-                </h2>
-              </div>
-              <p className="max-w-2xl self-end text-lg leading-relaxed text-black/60 sm:text-xl">
-                Tracklet ne transforme pas votre quotidien en logiciel comptable. Il vous aide à enregistrer les mouvements essentiels et à garder l’argent personnel séparé de l’activité.
-              </p>
-            </div>
-
-            <ol className="mt-16 grid border-l border-t border-black md:grid-cols-3">
-              {[
-                ["01", "Séparez", "Créez vos poches personnelles et professionnelles."],
-                ["02", "Enregistrez", "Ajoutez revenus, dépenses, transferts, ventes et dettes."],
-                ["03", "Comprenez", "Lisez votre trésorerie, vos rapports et vos objectifs."],
-              ].map(([number, title, copy]) => (
-                <li key={number} className="border-b border-r border-black p-6 sm:p-8">
-                  <span className="block text-7xl font-bold leading-none tracking-[-0.08em] text-[#002FA7] sm:text-8xl">{number}</span>
-                  <h3 className="mt-10 text-2xl font-bold tracking-[-0.04em]">{title}</h3>
-                  <p className="mt-3 max-w-xs leading-relaxed text-black/60">{copy}</p>
-                </li>
-              ))}
-            </ol>
-          </div>
-        </section>
-
-        <section id="produit" className="scroll-mt-20 border-b border-black/20 bg-[#F7F7F8]">
-          <div className="mx-auto max-w-[1440px] px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
-            <div className="mb-14 flex flex-col justify-between gap-6 border-b border-black pb-8 md:flex-row md:items-end">
-              <h2 className="max-w-3xl text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
-                Les outils qui suivent vraiment votre cash.
+        <section id="pourquoi" className="scroll-mt-24 bg-[#D4B895] px-5 py-20 sm:px-8 sm:py-28 lg:px-10">
+          <div className="mx-auto max-w-7xl">
+            <div className="grid gap-7 lg:grid-cols-[0.8fr_1.2fr] lg:items-end">
+              <h2 className="max-w-xl text-4xl font-bold leading-[1.02] tracking-[-0.055em] sm:text-6xl">
+                Trois réponses avant de prendre une décision.
               </h2>
-              <p className="max-w-sm text-base leading-relaxed text-black/60">
-                Pas de données décoratives : chaque écran répond à une décision financière concrète.
+              <p className="max-w-2xl text-lg leading-relaxed text-[#30351F]/85 lg:justify-self-end">
+                Tracklet réduit les données à ce qui aide maintenant : l’argent disponible, le résultat de l’activité et les mouvements encore attendus.
               </p>
             </div>
 
-            <ul className="grid auto-rows-auto border-l border-t border-black md:grid-cols-2 lg:grid-cols-3">
-              {productFeatures.map(({ title, description, icon: Icon, className = "", content }) => (
-                <li key={title} className={`min-h-72 border-b border-r border-black bg-white p-6 sm:p-8 ${className}`}>
-                  <div className="flex items-start justify-between gap-6">
-                    <div>
-                      <h3 className="text-2xl font-bold tracking-[-0.04em]">{title}</h3>
-                      <p className="mt-3 max-w-md leading-relaxed text-black/60">{description}</p>
-                    </div>
-                    <Icon aria-hidden="true" className="h-6 w-6 shrink-0 text-[#002FA7]" />
-                  </div>
-                  {content}
+            <ul className="mt-14 grid gap-5 lg:grid-cols-3">
+              {outcomes.map(({ icon: Icon, title, description }) => (
+                <li key={title} className="rounded-[2rem] border border-[#465024]/25 bg-[#E8DCC7] p-7 sm:p-8">
+                  <Icon aria-hidden="true" className="h-7 w-7 text-[#C66B3D]" />
+                  <h3 className="mt-10 text-2xl font-bold tracking-[-0.04em]">{title}</h3>
+                  <p className="mt-4 leading-relaxed text-[#30351F]/75">{description}</p>
                 </li>
               ))}
             </ul>
           </div>
         </section>
 
-        <section id="confidentialite" className="scroll-mt-20 bg-[#002FA7] text-white">
-          <div className="mx-auto grid max-w-[1440px] lg:grid-cols-2">
-            <div className="border-white/35 px-5 py-20 sm:px-8 lg:border-r lg:px-12 lg:py-28">
-              <LockKeyhole aria-hidden="true" className="mb-12 h-9 w-9" />
-              <h2 className="max-w-2xl text-4xl font-bold leading-[0.95] tracking-[-0.055em] sm:text-6xl">
-                Vos chiffres restent là où ils servent : chez vous.
+        <section id="fonctionnement" className="scroll-mt-24 px-5 py-20 sm:px-8 sm:py-28 lg:px-10">
+          <div className="mx-auto grid max-w-7xl gap-14 lg:grid-cols-[0.78fr_1.22fr]">
+            <div className="lg:sticky lg:top-28 lg:self-start">
+              <Leaf aria-hidden="true" className="h-8 w-8 text-[#465024]" />
+              <h2 className="mt-8 max-w-lg text-4xl font-bold leading-[1.02] tracking-[-0.055em] sm:text-6xl">
+                Une question à la fois.
               </h2>
-            </div>
-            <div className="flex flex-col justify-between px-5 py-20 sm:px-8 lg:px-12 lg:py-28">
-              <p className="max-w-xl text-lg leading-relaxed text-white/75 sm:text-xl">
-                Les données financières sont stockées dans le navigateur. Tracklet n’exige ni compte, ni serveur, ni synchronisation cloud pour fonctionner.
+              <p className="mt-6 max-w-md text-lg leading-relaxed text-[#30351F]/75">
+                Ouvrez seulement l’explication dont vous avez besoin. Dans l’application, chaque donnée reste liée à une action concrète.
               </p>
-              <ul className="mt-14 border-t border-white/45">
-                {[
-                  "Stockage local avec IndexedDB",
-                  "Sauvegarde JSON exportable et restaurable",
-                  "Aucune télémétrie financière",
-                  "Exports à conserver comme des documents sensibles",
-                ].map((item) => (
-                  <li key={item} className="flex items-center gap-3 border-b border-white/45 py-4 text-sm font-medium">
-                    <Check aria-hidden="true" className="h-4 w-4 shrink-0" />
+            </div>
+
+            <div className="space-y-4">
+              {answers.map(({ question, answer, items }, index) => {
+                const isOpen = openAnswer === index;
+                const buttonId = `landing-question-${index}`;
+                const panelId = `landing-answer-${index}`;
+
+                return (
+                  <div key={question} className={`rounded-[2rem] border border-[#465024]/25 ${isOpen ? "bg-[#E8DCC7]" : "bg-[#D4B895]"}`}>
+                    <h3>
+                      <button
+                        id={buttonId}
+                        type="button"
+                        onClick={() => setOpenAnswer(isOpen ? null : index)}
+                        className="flex min-h-20 w-full items-center justify-between gap-5 rounded-[2rem] px-6 py-5 text-left text-lg font-bold tracking-[-0.025em] sm:px-8 sm:text-xl"
+                        aria-expanded={isOpen}
+                        aria-controls={panelId}
+                      >
+                        {question}
+                        <ChevronDown aria-hidden="true" className={`h-5 w-5 shrink-0 text-[#465024] transition-transform duration-300 ${isOpen ? "rotate-180" : ""}`} />
+                      </button>
+                    </h3>
+                    {isOpen && (
+                      <div id={panelId} role="region" aria-labelledby={buttonId} className="px-6 pb-7 sm:px-8 sm:pb-8">
+                        <p className="max-w-2xl leading-relaxed text-[#30351F]/75">{answer}</p>
+                        <ul className="mt-6 grid gap-3 sm:grid-cols-3">
+                          {items.map((item) => (
+                            <li key={item} className="flex min-h-12 items-center gap-2 rounded-2xl bg-[#8B9D83]/30 px-4 text-sm font-medium">
+                              <Check aria-hidden="true" className="h-4 w-4 shrink-0 text-[#465024]" />
+                              {item}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section id="confidentialite" className="scroll-mt-24 bg-[#465024] px-5 py-20 text-[#E8DCC7] sm:px-8 sm:py-28 lg:px-10">
+          <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-2 lg:items-center">
+            <div>
+              <LockKeyhole aria-hidden="true" className="h-9 w-9 text-[#D4B895]" />
+              <h2 className="mt-8 max-w-2xl text-4xl font-bold leading-[1.02] tracking-[-0.055em] sm:text-6xl">
+                Un outil local, avec une sortie de secours.
+              </h2>
+              <p className="mt-7 max-w-xl text-lg leading-relaxed text-[#E8DCC7]/80">
+                Les données financières restent dans IndexedDB sur cet appareil. Tracklet fonctionne sans compte, télémétrie ou serveur financier.
+              </p>
+            </div>
+
+            <div className="rounded-[2rem] bg-[#E8DCC7] p-7 text-[#30351F] sm:p-9">
+              <FileDown aria-hidden="true" className="h-7 w-7 text-[#C66B3D]" />
+              <h3 className="mt-8 text-2xl font-bold tracking-[-0.04em]">Vous gardez une copie.</h3>
+              <p className="mt-4 leading-relaxed text-[#30351F]/75">
+                Exportez une sauvegarde JSON complète puis restaurez-la après confirmation. Le fichier n’est pas chiffré : conservez-le comme un document financier privé.
+              </p>
+              <ul className="mt-7 space-y-3 text-sm font-medium">
+                {["Toutes les données dans une sauvegarde", "Restauration transactionnelle", "Rapports CSV par période"].map((item) => (
+                  <li key={item} className="flex items-center gap-3">
+                    <Check aria-hidden="true" className="h-4 w-4 shrink-0 text-[#465024]" />
                     {item}
                   </li>
                 ))}
@@ -313,38 +303,77 @@ export function Landing() {
           </div>
         </section>
 
-        <section className="landing-grid border-b border-black/20">
-          <div className="mx-auto flex max-w-[1440px] flex-col items-start justify-between gap-12 px-5 py-20 sm:px-8 lg:flex-row lg:items-end lg:px-12 lg:py-28">
+        <section className="px-5 py-20 sm:px-8 sm:py-28 lg:px-10">
+          <div className="mx-auto flex max-w-7xl flex-col items-start justify-between gap-10 rounded-[2rem] bg-[#D98E69] p-8 text-[#30351F] sm:p-12 lg:flex-row lg:items-end">
             <div>
-              <p className="mb-6 text-sm font-semibold text-[#002FA7]">Prêt sur ce navigateur</p>
-              <h2 className="max-w-4xl text-5xl font-bold leading-[0.9] tracking-[-0.065em] sm:text-7xl lg:text-8xl">
-                Commencez par une poche. Voyez enfin l’ensemble.
+              <Smartphone aria-hidden="true" className="h-8 w-8" />
+              <h2 className="mt-8 max-w-3xl text-4xl font-bold leading-[1.02] tracking-[-0.055em] sm:text-6xl">
+                Commencez avec une seule poche.
               </h2>
+              <p className="mt-5 max-w-xl text-lg leading-relaxed">
+                Ajoutez Espèces ou Mobile Money, puis enregistrez le prochain mouvement réel.
+              </p>
             </div>
-            <Link
-              to="/dashboard"
-              className="inline-flex shrink-0 items-center gap-3 bg-[#002FA7] px-6 py-4 text-base font-semibold text-white transition-colors hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#002FA7]"
-            >
-              Ouvrir l’application
+            <Link to="/dashboard" className="inline-flex min-h-13 shrink-0 items-center gap-3 rounded-2xl bg-[#30351F] px-6 font-semibold text-[#E8DCC7] transition-colors duration-300 hover:bg-[#465024]">
+              Ouvrir Tracklet
               <ArrowRight aria-hidden="true" className="h-5 w-5" />
             </Link>
           </div>
         </section>
       </main>
 
-      <footer className="border-t border-black/20 bg-white text-black">
-        <div className="mx-auto flex max-w-[1440px] flex-col justify-between gap-8 px-5 py-10 sm:px-8 md:flex-row md:items-end lg:px-12">
+      <footer className="border-t border-[#465024]/25 px-5 py-10 sm:px-8 lg:px-10">
+        <div className="mx-auto flex max-w-7xl flex-col justify-between gap-7 sm:flex-row sm:items-end">
           <div>
-            <p className="text-2xl font-bold tracking-[-0.04em]">Tracklet</p>
-            <p className="mt-2 max-w-sm text-sm text-black/55">Copilote financier local pour les micro-entrepreneurs francophones.</p>
+            <p className="text-xl font-bold tracking-[-0.04em]">Tracklet</p>
+            <p className="mt-2 max-w-md text-sm leading-relaxed text-[#30351F]/75">
+              Copilote financier local pour les micro-entrepreneurs francophones.
+            </p>
           </div>
-          <div className="flex flex-wrap gap-x-6 gap-y-3 text-sm text-black/65">
-            <button type="button" onClick={() => scrollToSection("produit")} className="hover:text-[#002FA7]">Produit</button>
-            <button type="button" onClick={() => scrollToSection("confidentialite")} className="hover:text-[#002FA7]">Confidentialité</button>
-            <Link to="/dashboard" className="hover:text-[#002FA7]">Application</Link>
-          </div>
+          <Link to="/dashboard" className="inline-flex min-h-11 items-center gap-2 font-semibold text-[#465024] underline decoration-[#465024]/35 underline-offset-4 hover:decoration-[#465024]">
+            Ouvrir Tracklet
+            <ArrowRight aria-hidden="true" className="h-4 w-4" />
+          </Link>
         </div>
       </footer>
+    </div>
+  );
+}
+
+function MoneyFlow() {
+  return (
+    <div className="organic-breathe rounded-[2rem] bg-[#D4B895] p-5 sm:p-7" aria-label="Séparation des finances personnelles et professionnelles">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-[1.5rem] bg-[#E8DCC7] p-5">
+          <Smartphone aria-hidden="true" className="h-6 w-6 text-[#C66B3D]" />
+          <p className="mt-7 text-lg font-bold">Personnel</p>
+          <p className="mt-2 text-sm leading-relaxed text-[#30351F]/75">Espèces, Mobile Money, revenus et dépenses du foyer.</p>
+        </div>
+        <div className="rounded-[1.5rem] bg-[#8B9D83] p-5 text-[#252A18]">
+          <BriefcaseBusiness aria-hidden="true" className="h-6 w-6 text-[#30351F]" />
+          <p className="mt-7 text-lg font-bold">Activité</p>
+          <p className="mt-2 text-sm leading-relaxed">Caisse, ventes, charges et poches professionnelles.</p>
+        </div>
+      </div>
+
+      <svg className="my-2 h-28 w-full" viewBox="0 0 600 120" fill="none" aria-hidden="true">
+        <path d="M140 0C140 62 300 42 300 120" stroke="#C66B3D" strokeWidth="5" strokeLinecap="round" />
+        <path d="M460 0C460 62 300 42 300 120" stroke="#465024" strokeWidth="5" strokeLinecap="round" />
+        <circle cx="300" cy="82" r="10" fill="#C08E3A" />
+      </svg>
+
+      <div className="rounded-[1.5rem] bg-[#465024] p-6 text-[#E8DCC7]">
+        <div className="flex items-start justify-between gap-5">
+          <div>
+            <p className="text-sm font-medium text-[#E8DCC7]/80">Votre position de trésorerie</p>
+            <p className="mt-3 text-2xl font-bold leading-tight tracking-[-0.04em]">Une lecture commune, sans mélanger les poches.</p>
+          </div>
+          <Banknote aria-hidden="true" className="h-7 w-7 shrink-0 text-[#D4B895]" />
+        </div>
+        <p className="mt-6 rounded-2xl bg-[#E8DCC7]/10 px-4 py-3 text-sm leading-relaxed">
+          Soldes − sommes à payer + sommes à recevoir
+        </p>
+      </div>
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
           },
         ],
       },
-      workbox: { globPatterns: ["**/*.{js,css,html,ico,png,svg}"] },
+      workbox: { globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"] },
     }),
   ],
   test: {


### PR DESCRIPTION
## Summary

- Replace the Swiss/editorial landing direction with a warmer organic identity built around sand, sage, deep moss, and terracotta.
- Remove the chapter numbering and bento-style storytelling that made the page feel too close to WiseMoney.
- Make the personal/business separation the signature visual: two distinct money streams converge into Tracklet’s cash-position model.
- Keep every claim grounded in implemented behavior, with no fabricated balances, customer counts, or testimonials.

## UX improvements

- Lead with the user problem and a single consistent primary action: **Ouvrir Tracklet**.
- Add a complete mobile navigation with managed focus and Escape-to-close behavior.
- Organize product information around outcomes and progressively disclosed questions.
- Use 44px-or-larger interaction targets, visible two-tone focus rings, reduced-motion support, and WCAG-readable color contrast.
- Bundle Epilogue locally and precache the font for the offline PWA experience.

## Documentation

- Update `DESIGN.md` with the new landing palette, typography, structure, signature motif, accessibility rules, and visual restrictions.

## Validation

- `npm run check` — lint, 15 tests, TypeScript, and production PWA build pass.
- `npm audit --omit=dev` — 0 known vulnerabilities.
- Desktop and 390px mobile production renders inspected.
- Mobile menu focus/escape behavior and accordion state verified in-browser.
- `git diff --check` passes.